### PR TITLE
chore: establish development workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,13 @@
-#.github\dependabot.yml
 version: 2
 updates:
   - package-ecosystem: "mix"
     directory: "/"
+    target-branch: "development"
     schedule:
       interval: "daily"
 
   - package-ecosystem: "docker"
     directory: "/"
+    target-branch: "development"
     schedule:
       interval: "weekly"

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -36,12 +36,6 @@ jobs:
     - name: Install dependencies
       run: mix deps.get
 
-    - name: Check formatting
-      run: mix format --check-formatted
-
-    - name: Compile with warnings as errors
-      run: mix compile --warnings-as-errors
-
     - name: Run tests
       run: mix test
 

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -2,9 +2,9 @@ name: Elixir CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "development" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "development" ]
   workflow_dispatch:
 
 permissions:
@@ -22,8 +22,8 @@ jobs:
     - name: Set up Elixir
       uses: erlef/setup-beam@v1
       with:
-        elixir-version: '1.17' # Define the Elixir version
-        otp-version: '27'      # Define the Erlang/OTP version
+        elixir-version: '1.17'
+        otp-version: '27'
 
     - name: Restore dependencies cache
       uses: actions/cache@v3
@@ -35,6 +35,12 @@ jobs:
 
     - name: Install dependencies
       run: mix deps.get
+
+    - name: Check formatting
+      run: mix format --check-formatted
+
+    - name: Compile with warnings as errors
+      run: mix compile --warnings-as-errors
 
     - name: Run tests
       run: mix test

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -7,10 +7,9 @@ name: trivy
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "development" ]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: [ "main", "development" ]
   schedule:
     - cron: '33 6 * * 1'
 
@@ -20,9 +19,9 @@ permissions:
 jobs:
   build:
     permissions:
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+      contents: read
+      security-events: write
+      actions: read
     name: Build
     runs-on: "ubuntu-latest"
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing to Image Unmirrorer
+
+## Branch model
+
+This repository uses a lightweight development workflow with two long-lived branches:
+
+- `main`: stable, releasable code.
+- `development`: integration branch for ongoing development.
+
+Regular development must not be committed directly to either long-lived branch.
+
+## Working branches
+
+Create short-lived branches from `development` using one of these prefixes:
+
+- `feature/` for new functionality
+- `fix/` for bug fixes
+- `refactor/` for internal code improvements
+- `chore/` for maintenance and tooling
+- `docs/` for documentation changes
+- `test/` for test-only changes
+
+Example:
+
+```bash
+git switch development
+git pull
+git switch -c feature/add-image-validation
+```
+
+## Pull requests
+
+Normal changes follow this path:
+
+```text
+feature/*, fix/*, refactor/*, chore/*, docs/*, test/*
+                         |
+                         v
+                    development
+                         |
+                         v
+                       main
+```
+
+1. Open regular pull requests against `development`.
+2. CI must pass before merging.
+3. When `development` is ready for release, open a pull request from `development` to `main`.
+4. `main` should always represent a stable and releasable state.
+
+## Commits
+
+Use concise Conventional Commit messages when practical:
+
+```text
+feat: add image validation
+fix: handle unsupported image format
+refactor: simplify image processing
+chore: update dependencies
+docs: document API usage
+test: add image processing tests
+```
+
+## Local validation
+
+Before opening a pull request, run:
+
+```bash
+mix format --check-formatted
+mix compile --warnings-as-errors
+mix test
+```
+
+## Dependency updates
+
+Dependabot pull requests target `development` and follow the same CI and merge rules as other changes.


### PR DESCRIPTION
## What changed

- introduces `development` as the integration branch
- validates both `development` and `main` with the Elixir and Trivy workflows
- adds formatting and warnings-as-errors checks to Elixir CI
- targets future Dependabot pull requests to `development`
- documents the branch, pull request, commit, and release flow in `CONTRIBUTING.md`

## Workflow

Regular work should branch from and merge back into `development`. Stable releases move from `development` to `main` through a pull request.

## Validation

GitHub Actions will validate the proposed workflow changes on this pull request.