### PR TITLE
ci: add owner-only manual Gigalixir deploy

### DIFF
--- a/.github/workflows/deploy-gigalixir.yml
+++ b/.github/workflows/deploy-gigalixir.yml
@@ -1,0 +1,52 @@
+name: Deploy to Gigalixir
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gigalixir-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy to Gigalixir
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == github.repository_owner }}
+
+    steps:
+      - name: Checkout selected revision
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify deployment source
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Repository owner: ${{ github.repository_owner }}"
+          echo "Triggered by: ${{ github.actor }}"
+          echo "Selected ref: ${{ github.ref_name }}"
+          echo "Commit: ${{ github.sha }}"
+
+      - name: Configure Gigalixir credentials
+        shell: bash
+        env:
+          GIGALIXIR_EMAIL: ${{ secrets.GIGALIXIR_EMAIL }}
+          GIGALIXIR_API_KEY: ${{ secrets.GIGALIXIR_API_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "$GIGALIXIR_EMAIL" || { echo "GIGALIXIR_EMAIL secret is not configured" >&2; exit 1; }
+          test -n "$GIGALIXIR_API_KEY" || { echo "GIGALIXIR_API_KEY secret is not configured" >&2; exit 1; }
+          git config --global credential.helper store
+          printf 'https://%s:%s@git.gigalixir.com\n' "$GIGALIXIR_EMAIL" "$GIGALIXIR_API_KEY" > "$HOME/.git-credentials"
+          chmod 600 "$HOME/.git-credentials"
+
+      - name: Deploy selected commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          git remote add gigalixir https://git.gigalixir.com/image-unmirrorer.git
+          git push --force-with-lease gigalixir HEAD:refs/heads/main

--- a/.github/workflows/deploy-gigalixir.yml
+++ b/.github/workflows/deploy-gigalixir.yml
@@ -35,13 +35,13 @@ jobs:
         shell: bash
         env:
           GIGALIXIR_EMAIL: ${{ secrets.GIGALIXIR_EMAIL }}
-          GIGALIXIR_API_KEY: ${{ secrets.GIGALIXIR_API_KEY }}
+          GIGALIXIR_GIT_PASSWORD: ${{ secrets.GIGALIXIR_GIT_PASSWORD }}
         run: |
           set -euo pipefail
           test -n "$GIGALIXIR_EMAIL" || { echo "GIGALIXIR_EMAIL secret is not configured" >&2; exit 1; }
-          test -n "$GIGALIXIR_API_KEY" || { echo "GIGALIXIR_API_KEY secret is not configured" >&2; exit 1; }
+          test -n "$GIGALIXIR_GIT_PASSWORD" || { echo "GIGALIXIR_GIT_PASSWORD secret is not configured" >&2; exit 1; }
           git config --global credential.helper store
-          printf 'https://%s:%s@git.gigalixir.com\n' "$GIGALIXIR_EMAIL" "$GIGALIXIR_API_KEY" > "$HOME/.git-credentials"
+          printf 'https://%s:%s@git.gigalixir.com\n' "$GIGALIXIR_EMAIL" "$GIGALIXIR_GIT_PASSWORD" > "$HOME/.git-credentials"
           chmod 600 "$HOME/.git-credentials"
 
       - name: Deploy selected commit


### PR DESCRIPTION
## What changed

Adds a manual GitHub Actions workflow for deploying Image Unmirrorer to Gigalixir.

### Safety controls

- runs only via `workflow_dispatch`
- deploy job runs only when `github.actor == github.repository_owner`
- repository contents permission is read-only
- deployment concurrency prevents overlapping production deploys
- Gigalixir credentials are read only from GitHub Actions secrets

### Required repository secrets

- `GIGALIXIR_EMAIL`
- `GIGALIXIR_GIT_PASSWORD` — password from the `git.gigalixir.com` entry in `_netrc`

### Deployment behavior

The workflow deploys the exact revision selected in the GitHub **Run workflow** dialog to the `main` branch of the existing `image-unmirrorer` Gigalixir app.

This PR targets `development` in accordance with the repository workflow.