### PR TITLE
fix: configure Gigalixir git authentication

### DIFF
--- a/.github/workflows/deploy-gigalixir.yml
+++ b/.github/workflows/deploy-gigalixir.yml
@@ -40,13 +40,15 @@ jobs:
           set -euo pipefail
           test -n "$GIGALIXIR_EMAIL" || { echo "GIGALIXIR_EMAIL secret is not configured" >&2; exit 1; }
           test -n "$GIGALIXIR_GIT_PASSWORD" || { echo "GIGALIXIR_GIT_PASSWORD secret is not configured" >&2; exit 1; }
+
           git config --global credential.helper store
-          printf 'https://%s:%s@git.gigalixir.com\n' "$GIGALIXIR_EMAIL" "$GIGALIXIR_GIT_PASSWORD" > "$HOME/.git-credentials"
-          chmod 600 "$HOME/.git-credentials"
+          printf 'protocol=https\nhost=git.gigalixir.com\nusername=%s\npassword=%s\n\n' \
+            "$GIGALIXIR_EMAIL" \
+            "$GIGALIXIR_GIT_PASSWORD" | git credential approve
 
       - name: Deploy selected commit
         shell: bash
         run: |
           set -euo pipefail
           git remote add gigalixir https://git.gigalixir.com/image-unmirrorer.git
-          git push --force-with-lease gigalixir HEAD:refs/heads/main
+          git push gigalixir HEAD:refs/heads/main


### PR DESCRIPTION
## What changed

Fixes authentication for the manual Gigalixir deployment workflow.

## Root cause

The first deployment reached `git push`, but Git could not retrieve the username from the manually written `.git-credentials` entry and failed with `could not read Username for 'https://git.gigalixir.com'`.

## Fix

- registers the existing `GIGALIXIR_EMAIL` and `GIGALIXIR_GIT_PASSWORD` secrets through `git credential approve`
- avoids embedding credentials directly in the remote URL
- removes `--force-with-lease` and uses a normal push to the Gigalixir `main` branch
- keeps the existing owner-only `workflow_dispatch` restriction

Targets `development` according to the repository development workflow.